### PR TITLE
perf: nvim プラグインの遅延ロードを最適化

### DIFF
--- a/configs/nvim/init.lua
+++ b/configs/nvim/init.lua
@@ -204,7 +204,7 @@ require('lazy').setup({
 
   { -- Useful plugin to show you pending keybinds.
     'folke/which-key.nvim',
-    event = 'VimEnter', -- Sets the loading event to 'VimEnter'
+    event = 'VeryLazy', -- Sets the loading event to 'VeryLazy'
     opts = {
       triggers = {
         { '<leader>', mode = { 'n', 'v' } },
@@ -695,7 +695,7 @@ require('lazy').setup({
   },
 
   -- Highlight todo, notes, etc in comments
-  { 'folke/todo-comments.nvim', event = 'VimEnter', dependencies = { 'nvim-lua/plenary.nvim' }, opts = { signs = false } },
+  { 'folke/todo-comments.nvim', event = 'BufReadPost', dependencies = { 'nvim-lua/plenary.nvim' }, opts = { signs = false } },
 
   { -- Collection of various small independent plugins/modules
     'echasnovski/mini.nvim',

--- a/configs/nvim/lua/custom/plugins/diffview.lua
+++ b/configs/nvim/lua/custom/plugins/diffview.lua
@@ -1,9 +1,9 @@
 return {
   'sindrets/diffview.nvim',
-  event = 'VeryLazy',
-  config = function()
-    vim.keymap.set('n', '<leader>dd', ':DiffviewOpen<CR>', { noremap = true, silent = true, desc = 'Diffview Open' })
-    vim.keymap.set('n', '<leader>da', ':DiffviewOpen<CR> HEAD', { noremap = true, silent = true, desc = 'Git Diff All' })
-    vim.keymap.set('n', '<leader>dc', ':DiffviewClose<CR>', { noremap = true, silent = true, desc = 'Git Diff Close' })
-  end,
+  cmd = { 'DiffviewOpen', 'DiffviewClose', 'DiffviewFileHistory' },
+  keys = {
+    { '<leader>dd', ':DiffviewOpen<CR>', noremap = true, silent = true, desc = 'Diffview Open' },
+    { '<leader>da', ':DiffviewOpen HEAD<CR>', noremap = true, silent = true, desc = 'Git Diff All' },
+    { '<leader>dc', ':DiffviewClose<CR>', noremap = true, silent = true, desc = 'Git Diff Close' },
+  },
 }

--- a/configs/nvim/lua/custom/plugins/essentials.lua
+++ b/configs/nvim/lua/custom/plugins/essentials.lua
@@ -1,8 +1,8 @@
 return {
-  { 'unblevable/quick-scope' },
-  { 'rhysd/clever-f.vim' },
-  { 'kylechui/nvim-surround' },
-  { 'gbprod/substitute.nvim' },
-  { 'https://codeberg.org/andyg/leap.nvim' },
-  { 'monaqa/dial.nvim' },
+  { 'unblevable/quick-scope', event = 'VeryLazy' },
+  { 'rhysd/clever-f.vim', event = 'VeryLazy' },
+  { 'kylechui/nvim-surround', event = 'VeryLazy' },
+  { 'gbprod/substitute.nvim', event = 'VeryLazy' },
+  { 'https://codeberg.org/andyg/leap.nvim', event = 'VeryLazy' },
+  { 'monaqa/dial.nvim', event = 'VeryLazy' },
 }

--- a/configs/nvim/lua/custom/plugins/glance.lua
+++ b/configs/nvim/lua/custom/plugins/glance.lua
@@ -1,10 +1,10 @@
 return {
   'dnlhc/glance.nvim',
-  event = 'VeryLazy',
-  config = function()
-    vim.keymap.set('n', '<leader>ld', '<CMD>Glance definitions<CR>')
-    vim.keymap.set('n', '<leader>lr', '<CMD>Glance references<CR>')
-    vim.keymap.set('n', '<leader>ly', '<CMD>Glance type_definitions<CR>')
-    vim.keymap.set('n', '<leader>lm', '<CMD>Glance implementations<CR>')
-  end,
+  cmd = 'Glance',
+  keys = {
+    { '<leader>ld', '<CMD>Glance definitions<CR>', desc = 'Glance Definitions' },
+    { '<leader>lr', '<CMD>Glance references<CR>', desc = 'Glance References' },
+    { '<leader>ly', '<CMD>Glance type_definitions<CR>', desc = 'Glance Type Definitions' },
+    { '<leader>lm', '<CMD>Glance implementations<CR>', desc = 'Glance Implementations' },
+  },
 }


### PR DESCRIPTION
## Summary
- essentials.lua の6プラグイン（quick-scope, clever-f, nvim-surround, substitute, leap, dial）に `event = 'VeryLazy'` を追加し起動時ロードを解消
- which-key を `VimEnter` → `VeryLazy` に変更
- todo-comments を `VimEnter` → `BufReadPost` に変更（ファイルを開くまで不要）
- diffview, glance を `event = 'VeryLazy'` → `cmd` + `keys` のオンデマンドロードに変更

## Test plan
- [ ] `nvim` 起動時にエラーが出ないこと
- [ ] `:Lazy` でプラグインのロード状態を確認（対象プラグインが遅延ロードになっていること）
- [ ] essentials 系キー操作（f/t移動, surround, leap, dial）が正常に動作すること
- [ ] `<leader>dd` / `<leader>dc` で diffview が正常に開閉すること
- [ ] `<leader>ld` / `<leader>lr` で glance が正常に動作すること
- [ ] which-key がキー押下時に正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)