### PR TITLE
fix: Claude Code 通知のアシスタント返信抽出を改行対応

### DIFF
--- a/configs/claude-code/hooks/notify-send.sh
+++ b/configs/claude-code/hooks/notify-send.sh
@@ -17,11 +17,23 @@ fi
 
 summary=""
 if [ "$event" = "Stop" ] && [ -n "$transcript" ] && [ -f "$transcript" ] && command -v jq >/dev/null 2>&1; then
-  summary="$(jq -r '
+  summary="$(jq -rc '
     select(.type == "assistant")
     | [.message.content[]? | select(.type == "text") | .text]
     | join(" ")
+    | gsub("\\s+"; " ")
   ' "$transcript" 2>/dev/null | awk 'NF' | tail -n 1)"
+fi
+
+if [ -n "${CLAUDE_NOTIFY_DEBUG:-}" ]; then
+  {
+    date -Iseconds
+    printf 'event=%s\n' "$event"
+    printf 'transcript=%s\n' "$transcript"
+    printf 'summary=%s\n' "$summary"
+    printf 'payload=%s\n' "$payload"
+    printf -- '---\n'
+  } >> /tmp/claude-notify-debug.log 2>/dev/null || true
 fi
 
 case "$event" in


### PR DESCRIPTION
## Summary
- `notify-send.sh` hook が Stop イベント時に transcript から直近のアシスタント返信を抽出する際、改行を含むメッセージで正しく本文を取得できずフォールバック (`ターンが返ってきました`) になっていた問題を修正
- jq 内で空白文字列を正規化 (`gsub("\\s+"; " ")`) して 1 メッセージ = 1 行を保証
- `CLAUDE_NOTIFY_DEBUG=1` でデバッグログ (`/tmp/claude-notify-debug.log`) を出せるようにした

## 背景
PR #69 で導入した hook は `jq -r` の出力に生の改行が混じるため、`awk 'NF' | tail -n 1` が 1 メッセージの末尾 1 行しか拾えず、結果的に空行などに当たってフォールバックしていた。

## Test plan
- [x] `sudo nixos-rebuild switch --flake .#air --impure` 成功
- [x] 既存 transcript での抽出結果を dry-run で検証済み
- [ ] tmux 内で新規セッションのターン終了通知に実際のアシスタント返信が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)