### PR TITLE
feat: add workmux status tracking hooks

### DIFF
--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -13,7 +13,6 @@ bind - split-window -v
 bind x kill-pane
 bind r source-file ~/.config/tmux/tmux.conf \; display-message "Reloaded"
 bind y set-window-option synchronize-panes
-bind t split-window -v -l 30%
 bind X kill-server
 
 # enable color
@@ -64,9 +63,9 @@ set -g message-command-style "bg=#414868,fg=#c0caf5"
 
 # workmux integration
 bind w display-popup -E "workmux dashboard"
-bind C-t run-shell "workmux sidebar"
-bind l run-shell "workmux last-done"
-bind Tab run-shell "workmux last-agent"
+bind t run-shell "workmux sidebar"
+bind Tab run-shell "workmux last-done"
+bind o run-shell "workmux last-agent"
 bind J run-shell "workmux sidebar next"
 bind K run-shell "workmux sidebar prev"
 

--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -62,6 +62,14 @@ set -uw pane-active-border-style
 set -g message-style "bg=#414868,fg=#c0caf5"
 set -g message-command-style "bg=#414868,fg=#c0caf5"
 
+# workmux integration
+bind w display-popup -E "workmux dashboard"
+bind C-t run-shell "workmux sidebar"
+bind l run-shell "workmux last-done"
+bind Tab run-shell "workmux last-agent"
+bind J run-shell "workmux sidebar next"
+bind K run-shell "workmux sidebar prev"
+
 # show pane synchronization status in status bar (center)
 set -g status 2
 set -g status-format[1] '#[align=centre]#{?pane_synchronized,#[bg=#f7768e]#[fg=#1a1b26]#[bold] 󰓦 SYNC MODE #[default],}#{?#{==:#{prefix},None},#[bg=#ff9e64]#[fg=#1a1b26]#[bold]  PREFIX DISABLED #[default],}'

--- a/modules/ai-agent.nix
+++ b/modules/ai-agent.nix
@@ -87,6 +87,11 @@ in
       - command: <agent>
         focus: true
       - split: horizontal
+    files:
+      copy:
+        - .env
+    post_create:
+      - pnpm install || true
   '';
 
   # rebuild 時に ~/.claude.json の mcpServers と autoCompactEnabled を Nix 管理の設定で同期

--- a/modules/ai-agent.nix
+++ b/modules/ai-agent.nix
@@ -134,6 +134,16 @@ in
             ];
           }
         ];
+        UserPromptSubmit = [
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "workmux set-window-status working";
+              }
+            ];
+          }
+        ];
         PostToolUse = [
           {
             matcher = "Write|Edit";
@@ -141,6 +151,14 @@ in
               {
                 type = "command";
                 command = "${promptEditHook}";
+              }
+            ];
+          }
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "workmux set-window-status working";
               }
             ];
           }
@@ -174,6 +192,15 @@ in
               }
             ];
           }
+          {
+            matcher = "permission_prompt|elicitation_dialog";
+            hooks = [
+              {
+                type = "command";
+                command = "workmux set-window-status waiting";
+              }
+            ];
+          }
         ];
         Stop = [
           {
@@ -181,6 +208,14 @@ in
               {
                 type = "command";
                 command = "~/.claude/hooks/notify-send.sh";
+              }
+            ];
+          }
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "workmux set-window-status done";
               }
             ];
           }


### PR DESCRIPTION
workmuxのsidebar/dashboardでエージェントの状態を表示するためのClaude Code hooksを追加。

既存のhooks（notify-send, promptEditHook等）と共存する形で、以下の4イベントにworkmux status trackingを追加:

| Event | Status | 用途 |
|---|---|---|
| UserPromptSubmit | working | ユーザーがプロンプト送信 |
| PostToolUse | working | ツール実行後（作業中） |
| Notification (permission_prompt\|elicitation_dialog) | waiting | 権限確認待ち |
| Stop | done | エージェント完了 |

前提: `workmux` は既に `home.packages` に含まれている（llm-agents-nix経由）。

適用後、`workmux sidebar` でtmux全ウィンドウにエージェント状態が表示される。