### PR TITLE
fix: workmux dashboard popup size + remove extra shell pane

### DIFF
--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -62,7 +62,7 @@ set -g message-style "bg=#414868,fg=#c0caf5"
 set -g message-command-style "bg=#414868,fg=#c0caf5"
 
 # workmux integration
-bind w display-popup -E "workmux dashboard"
+bind w display-popup -w90% -h90% -E "workmux dashboard"
 bind t run-shell "workmux sidebar"
 bind Tab run-shell "workmux last-done"
 bind o run-shell "workmux last-agent"

--- a/modules/ai-agent.nix
+++ b/modules/ai-agent.nix
@@ -86,7 +86,6 @@ in
     panes:
       - command: <agent>
         focus: true
-      - split: horizontal
     files:
       copy:
         - .env


### PR DESCRIPTION
1. **Dashboard popup**: `-w90% -h90%` 追加（lazygitと同じサイズ）
2. **Panes**: シェルペイン削除、agentペインのみに