### PR TITLE
fix: warp-terminal を niri 上で起動できるようにする

### DIFF
--- a/configs/niri-base.kdl
+++ b/configs/niri-base.kdl
@@ -3,6 +3,11 @@
 
 prefer-no-csd
 
+// X11 アプリ用 (Warp など)。xwayland-satellite を起動して DISPLAY=:0 を提供する
+environment {
+    DISPLAY ":0"
+}
+
 input {
     keyboard {
         xkb {
@@ -169,6 +174,7 @@ binds {
 
 spawn-at-startup "fcitx5"
 spawn-at-startup "kitty" "--class" "kitty-scratch" "-e" "tmux" "new-session" "-A" "-s" "scratch"
+spawn-at-startup "xwayland-satellite" ":0"
 
 // Monitor configuration
 output "DP-3" {

--- a/modules/nixos/niri.nix
+++ b/modules/nixos/niri.nix
@@ -10,6 +10,7 @@
     grim
     slurp
     satty
+    xwayland-satellite
     inputs.niri-scratchpad.packages.${pkgs.stdenv.hostPlatform.system}.default
   ];
 

--- a/modules/warp.nix
+++ b/modules/warp.nix
@@ -1,0 +1,14 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  home.packages = lib.mkAfter (
+    with pkgs;
+    [
+      warp-terminal
+    ]
+  );
+}


### PR DESCRIPTION
## Summary
- Warp の Linux バイナリは X11 専用ビルドで、純 Wayland の niri 上では winit が `NotSupported(NotSupportedError)` でパニックして起動できなかった
- `xwayland-satellite` を niri 起動時に常駐させ、`environment { DISPLAY ":0" }` で全 spawn プロセスに DISPLAY を継承させることで解消

## 背景・調査
`warp-terminal` 起動時に以下のクラッシュが発生:

```
thread 'main' panicked at .../crates/warpui/src/windowing/winit/app.rs:184:14:
should be able to create event loop: NotSupported(NotSupportedError)
```

`LD_DEBUG=libs` で dlopen の挙動を追跡したところ、Warp の winit は `libX11.so.6` / `libxcb.so.1` / `libXcursor.so.1` / `libXi.so.6` / `libXrender.so.1` のみを探索し、`libwayland-*` を一切試行しないことを確認 → **Warp は Linux 向けに X11 専用ビルドで配布されている**。

niri は純 Wayland で Xwayland を内蔵しない設計（公式に xwayland-satellite を別プロセスで動かす方針）のため、`DISPLAY` が立っておらず winit が両バックエンドの初期化に失敗していた。

amd64/aarch64 の差は無関係（NixOS ホストは全部 niri 利用なので一律影響）。Apple Silicon (Asahi GPU) も Xwayland 経由で wgpu/Vulkan 経由の `Apple M2 (G14G B0)` がレンダリングに使えることをログで確認済み。

## 動作確認
- `air` で `nixos-rebuild switch` 完了
- 手動で `xwayland-satellite :0` を起動し `DISPLAY=:0 warp-terminal` でクラッシュせず起動、`xwininfo` で `dev.warp.Warp` ウィンドウが niri 上に出現することを確認
- `niri validate` で `environment` ブロックの構文有効性を確認

## Test plan
- [ ] niri ログイン → 自動的に `xwayland-satellite` が起動していること (`pgrep xwayland-satellite`)
- [ ] `warp-terminal` がクラッシュせず起動すること
- [ ] 既存の Wayland ネイティブアプリ（kitty, rofi 等）に回帰がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)