### PR TITLE
feat: thunar をリスト表示・更新日降順デフォルトで有効化

### DIFF
--- a/configs/xfce4/xfconf/xfce-perchannel-xml/thunar.xml
+++ b/configs/xfce4/xfconf/xfce-perchannel-xml/thunar.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="thunar" version="1.0">
+  <property name="default-view" type="string" value="ThunarDetailsView"/>
+  <property name="last-view" type="string" value="ThunarDetailsView"/>
+  <property name="last-sort-column" type="string" value="THUNAR_COLUMN_DATE_MODIFIED"/>
+  <property name="last-sort-order" type="string" value="GTK_SORT_DESCENDING"/>
+</channel>

--- a/modules/nixos/system/thunar.nix
+++ b/modules/nixos/system/thunar.nix
@@ -1,10 +1,19 @@
 { pkgs, lib, username, homeDirectory, onNixOS, ... }:
 
 {
+  # Thunar 本体（xfconfd の D-Bus サービス登録、プラグイン統合まで面倒を見てくれる）
+  programs.thunar = {
+    enable = true;
+    plugins = with pkgs.xfce; [
+      thunar-volman # removable media management
+    ];
+  };
+
+  # xfconf-query などの CLI も使えるようにしておく
+  programs.xfconf.enable = true;
+
   environment.systemPackages = lib.mkAfter
     (with pkgs; [
-      thunar
-      thunar-volman  # removable media management
       tumbler        # thumbnail generation
       gvfs                # virtual filesystem (SMB, FTP, etc.)
       samba               # SMB/CIFS support
@@ -17,4 +26,10 @@
 
   # Enable tumbler service for thumbnail generation
   services.tumbler.enable = true;
+
+  # Thunar のデフォルト表示設定
+  # - 詳細リスト表示 (ThunarDetailsView)
+  # - 最終更新日の降順 (新しい順)
+  home-manager.users.${username}.home.file.".config/xfce4/xfconf/xfce-perchannel-xml/thunar.xml".source =
+    ../../../configs/xfce4/xfconf/xfce-perchannel-xml/thunar.xml;
 }


### PR DESCRIPTION
## Summary
- `programs.thunar.enable` / `programs.xfconf.enable` に切り替え。xfconfd の D-Bus サービス登録など NixOS 正規ルートで thunar をセットアップ
- `configs/xfce4/xfconf/xfce-perchannel-xml/thunar.xml` を追加し、`home-manager.users.<user>.home.file` で `~/.config/...` にデプロイ
- デフォルトを **詳細リスト表示** + **最終更新日の降順** に固定

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#$(hostname) --impure` が成功する
- [ ] `pkill xfconfd thunar` 後に `xfconf-query -c thunar -l -v` で `last-view=ThunarDetailsView`, `last-sort-column=THUNAR_COLUMN_DATE_MODIFIED`, `last-sort-order=GTK_SORT_DESCENDING` が表示される
- [ ] thunar を新規起動するとリスト表示で更新日降順になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)