### PR TITLE
feat: セキュリティ学習向けツール群を追加

### DIFF
--- a/modules/security.nix
+++ b/modules/security.nix
@@ -1,0 +1,60 @@
+{ pkgs, lib, ... }:
+
+{
+  home.packages = with pkgs; [
+    # --- Recon / Scanning ---
+    nmap
+    masscan
+    rustscan
+    whois
+    dnsutils
+    whatweb
+
+    # --- Web ---
+    ffuf
+    gobuster
+    feroxbuster
+    nikto
+    sqlmap
+    wfuzz
+    dirb
+
+    # --- Exploitation ---
+    metasploit
+
+    # --- Password / Hash ---
+    john
+    hashcat
+    thc-hydra
+    hashid
+
+    # --- SMB / AD / Windows ---
+    enum4linux
+    smbmap
+    impacket
+    netexec # crackmapexec の後継
+    responder
+
+    # --- Network ---
+    wireshark
+    tcpdump
+    netcat-gnu
+    socat
+
+    # --- Tunneling ---
+    chisel
+
+    # --- Wordlists / Resources ---
+    seclists
+    exploitdb
+
+    # --- Reverse Engineering / Binary ---
+    radare2
+    ghidra
+
+    # --- Forensics / Stego ---
+    binwalk
+    foremost
+    steghide
+  ];
+}


### PR DESCRIPTION
## Summary
- TryHackMe など、セキュリティ学習で常用するツールを `modules/security.nix` に集約して `home.packages` に追加
- nmap / rustscan / ffuf / gobuster / sqlmap / hashcat / john / metasploit / impacket / netexec / wireshark / radare2 / ghidra / binwalk など
- `modules/` 直下なので `home.nix` の自動 import 機構で取り込まれる（追加配線不要）

## Test plan
- [ ] `nix flake check --no-build` が通る
- [ ] `home-manager switch --flake . --impure` (もしくは `nixos-rebuild switch`) が成功
- [ ] `nmap`, `ffuf`, `hashcat` などが PATH から呼べる

🤖 Generated with [Claude Code](https://claude.com/claude-code)