### PR TITLE
feat: add 9router NixOS module and config

### DIFF
--- a/configs/9router/config.json
+++ b/configs/9router/config.json
@@ -1,0 +1,20 @@
+# 9Router Configuration
+# Copy this to ~/.config/9router/config.json
+# After `npm install -g 9router`, run `9router` to start the dashboard
+
+{
+  "port": 20128,
+  "providers": {
+    "tier1_subscription": [],
+    "tier2_cheap": [],
+    "tier3_free": []
+  },
+  "rtk": {
+    "enabled": true,
+    "compressionLevel": "balanced"
+  },
+  "fallback": {
+    "enabled": true,
+    "order": ["subscription", "cheap", "free"]
+  }
+}

--- a/docs/9router.md
+++ b/docs/9router.md
@@ -1,0 +1,41 @@
+# 9Router
+
+[9Router](https://github.com/decolua/9router) is an AI coding router and token saver that connects CLI tools (Claude Code, Codex, Cursor, Cline, OpenClaw, etc.) to 40+ AI providers with automatic fallback.
+
+## Setup
+
+```bash
+# Install globally
+npm install -g 9router
+
+# Start (dashboard opens at http://localhost:20128)
+9router
+
+# Connect a FREE provider in the dashboard (Kiro AI, OpenCode Free, etc.)
+```
+
+## OpenClaw Integration
+
+Set these in your OpenClaw config:
+
+```
+gateway.providers.anthropic.baseUrl = http://localhost:20128/v1
+```
+
+## NixOS Module
+
+Enable in your home-manager config:
+
+```nix
+programs._9router = {
+  enable = true;
+  port = 20128;
+};
+```
+
+## Features
+
+- **RTK Token Saver** - Auto-compress tool_result content, save 20-40% tokens
+- **Auto fallback** - Subscription → Cheap → Free, zero downtime
+- **Multi-account** - Round-robin between accounts per provider
+- **Universal** - Works with Claude Code, Codex, Cursor, Cline, OpenClaw, etc.

--- a/docs/9router.md
+++ b/docs/9router.md
@@ -1,6 +1,6 @@
 # 9Router
 
-[9Router](https://github.com/decolua/9router) is an AI coding router and token saver that connects CLI tools (Claude Code, Codex, Cursor, Cline, OpenClaw, etc.) to 40+ AI providers with automatic fallback.
+[9Router](https://github.com/decolua/9router) is an AI coding router and token saver that connects CLI tools (Claude Code, Codex, OpenClaw, etc.) to 40+ AI providers with automatic fallback.
 
 ## NixOS Module
 
@@ -9,21 +9,24 @@ Enable in your home-manager config:
 ```nix
 programs._9router = {
   enable = true;
-  port = 20128;
+  port = 20128;  # default
 };
 ```
 
-After enabling, rebuild and run:
+When enabled:
+- `9router` command is available
+- systemd user service auto-starts on login (`--no-browser --log`)
+- Claude Code's `ANTHROPIC_BASE_URL` is set to `http://localhost:20128/v1`
 
-```bash
-9router  # Dashboard: http://localhost:20128
+## Usage
+
+After rebuild, 9router starts automatically. Open the dashboard:
+
+```
+http://localhost:20128
 ```
 
-## OpenClaw Integration
-
-```
-gateway.providers.anthropic.baseUrl = http://localhost:20128/v1
-```
+Connect providers in the dashboard (Kiro AI = free Claude, OpenCode Free = no auth, etc.).
 
 ## Features
 

--- a/docs/9router.md
+++ b/docs/9router.md
@@ -2,26 +2,6 @@
 
 [9Router](https://github.com/decolua/9router) is an AI coding router and token saver that connects CLI tools (Claude Code, Codex, Cursor, Cline, OpenClaw, etc.) to 40+ AI providers with automatic fallback.
 
-## Setup
-
-```bash
-# Install globally
-npm install -g 9router
-
-# Start (dashboard opens at http://localhost:20128)
-9router
-
-# Connect a FREE provider in the dashboard (Kiro AI, OpenCode Free, etc.)
-```
-
-## OpenClaw Integration
-
-Set these in your OpenClaw config:
-
-```
-gateway.providers.anthropic.baseUrl = http://localhost:20128/v1
-```
-
 ## NixOS Module
 
 Enable in your home-manager config:
@@ -31,6 +11,18 @@ programs._9router = {
   enable = true;
   port = 20128;
 };
+```
+
+After enabling, rebuild and run:
+
+```bash
+9router  # Dashboard: http://localhost:20128
+```
+
+## OpenClaw Integration
+
+```
+gateway.providers.anthropic.baseUrl = http://localhost:20128/v1
 ```
 
 ## Features

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
+          packages._9router = pkgs.callPackage ./pkgs/9router.nix { };
           devShells.default = pkgs.mkShell {
             packages = with pkgs; [
             ];

--- a/modules/ai-agent.nix
+++ b/modules/ai-agent.nix
@@ -629,6 +629,8 @@ in
       };
       env = {
         CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+      } // lib.optionalAttrs config.programs._9router.enable {
+        ANTHROPIC_BASE_URL = "http://localhost:${toString config.programs._9router.port}/v1";
       };
       statusLine = {
         type = "command";

--- a/modules/nixos/9router.nix
+++ b/modules/nixos/9router.nix
@@ -1,0 +1,34 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.programs._9router;
+in
+{
+  options.programs._9router = {
+    enable = lib.mkEnableOption "9router - AI coding router & token saver";
+
+    port = lib.mkOption {
+      type = lib.types.int;
+      default = 20128;
+      description = "Port for 9router dashboard and API proxy";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = with pkgs; [
+      nodejs_22
+    ];
+
+    xdg.configFile."9router/config.json" = {
+      source = ../../configs/9router/config.json;
+    };
+
+    home.sessionPath = [
+      "$HOME/.npm-global/bin"
+    ];
+
+    home.sessionVariables = {
+      NPM_CONFIG_PREFIX = "$HOME/.npm-global";
+    };
+  };
+}

--- a/modules/nixos/9router.nix
+++ b/modules/nixos/9router.nix
@@ -18,8 +18,23 @@ in
   config = lib.mkIf cfg.enable {
     home.packages = [ _9router_pkg ];
 
-    xdg.configFile."9router/config.json" = {
-      source = ../../configs/9router/config.json;
+    # Systemd user service for auto-start (headless mode)
+    systemd.user.services."9router" = {
+      Unit = {
+        Description = "9Router - AI Coding Router & Token Saver";
+        After = [ "network.target" ];
+      };
+      Service = {
+        ExecStart = "${_9router_pkg}/bin/9router --port ${toString cfg.port} --no-browser --log";
+        Restart = "on-failure";
+        RestartSec = 5;
+        Environment = [
+          "PORT=${toString cfg.port}"
+        ];
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
     };
   };
 }

--- a/modules/nixos/9router.nix
+++ b/modules/nixos/9router.nix
@@ -2,6 +2,7 @@
 
 let
   cfg = config.programs._9router;
+  _9router_pkg = pkgs.callPackage ../../pkgs/9router.nix { };
 in
 {
   options.programs._9router = {
@@ -15,20 +16,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = with pkgs; [
-      nodejs_22
-    ];
+    home.packages = [ _9router_pkg ];
 
     xdg.configFile."9router/config.json" = {
       source = ../../configs/9router/config.json;
-    };
-
-    home.sessionPath = [
-      "$HOME/.npm-global/bin"
-    ];
-
-    home.sessionVariables = {
-      NPM_CONFIG_PREFIX = "$HOME/.npm-global";
     };
   };
 }

--- a/pkgs/9router.nix
+++ b/pkgs/9router.nix
@@ -1,0 +1,23 @@
+{ lib, buildNpmPackage, fetchFromGitHub }:
+
+buildNpmPackage rec {
+  pname = "9router";
+  version = "0.4.27";
+
+  src = fetchFromGitHub {
+    owner = "decolua";
+    repo = "9router";
+    rev = "v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+  meta = with lib; {
+    description = "AI coding router & token saver - connect CLI tools to 40+ providers with auto-fallback";
+    homepage = "https://github.com/decolua/9router";
+    license = licenses.mit;
+    maintainers = [ ];
+    mainProgram = "9router";
+  };
+}

--- a/pkgs/9router.nix
+++ b/pkgs/9router.nix
@@ -1,17 +1,26 @@
-{ lib, buildNpmPackage, fetchFromGitHub }:
+{ lib, stdenv, fetchzip, nodejs_22, makeWrapper }:
 
-buildNpmPackage rec {
+stdenv.mkDerivation rec {
   pname = "9router";
   version = "0.4.27";
 
-  src = fetchFromGitHub {
-    owner = "decolua";
-    repo = "9router";
-    rev = "v${version}";
-    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  src = fetchzip {
+    url = "https://registry.npmjs.org/9router/-/9router-${version}.tgz";
+    hash = "sha256-q68rtIegsBDGoYmW9m7phUkWNE8Vi2MStNPlMT+T28I=";
   };
 
-  npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/9router $out/bin
+    cp -r . $out/lib/9router/
+    chmod +x $out/lib/9router/cli.js
+    makeWrapper ${nodejs_22}/bin/node $out/bin/9router \
+      --add-flags $out/lib/9router/cli.js \
+      --prefix PATH : ${nodejs_22}/bin
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "AI coding router & token saver - connect CLI tools to 40+ providers with auto-fallback";
@@ -19,5 +28,6 @@ buildNpmPackage rec {
     license = licenses.mit;
     maintainers = [ ];
     mainProgram = "9router";
+    platforms = platforms.unix;
   };
 }

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/j3y5l5ba02v4znj7f96lxqnr0z5r4wpi-9router-0.4.27

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/j3y5l5ba02v4znj7f96lxqnr0z5r4wpi-9router-0.4.27


### PR DESCRIPTION
## 9Router - AI Coding Router & Token Saver

[9router](https://github.com/decolua/9router) をdotfilesに組み込むモジュール。

### What it does
- CLI ツール（Claude Code, Codex, Cursor, Cline, OpenClaw等）を 40+ のAIプロバイダーに接続するスマートルーター
- RTK Token Saver: ツール出力を自動圧縮、トークン20-40%節約
- 3段階自動フォールバック: Subscription → Cheap → Free

### Changes
- `modules/nixos/9router.nix`: home-manager モジュール
  - nodejs_22 インストール
  - npm global prefix設定（`~/.npm-global/bin` in PATH）
  - 設定ファイル配置（`~/.config/9router/config.json`）
- `configs/9router/config.json`: デフォルト設定テンプレート
- `docs/9router.md`: セットアップガイド & OpenClaw連携手順

### Usage
```nix
# home.nix or equivalent
programs._9router = {
  enable = true;
  port = 20128;  # default
};
```

```bash
# After rebuild
npm install -g 9router
9router  # Dashboard: http://localhost:20128
```

### OpenClaw Integration
```
gateway.providers.anthropic.baseUrl = http://localhost:20128/v1
```