### PR TITLE
feat: replace workmux sidebar with tmux-agent-sidebar

### DIFF
--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -60,13 +60,16 @@ set -uw pane-active-border-style
 set -g message-style "bg=#414868,fg=#c0caf5"
 set -g message-command-style "bg=#414868,fg=#c0caf5"
 
-# workmux integration
+# workmux integration (dashboard/navigation only, sidebar replaced by tmux-agent-sidebar)
 bind w display-popup -w90% -h90% -E "workmux dashboard"
-bind t run-shell "workmux sidebar"
 bind Tab run-shell "workmux last-done"
 bind o run-shell "workmux last-agent"
-bind J run-shell "workmux sidebar next"
-bind K run-shell "workmux sidebar prev"
+
+# tmux-agent-sidebar (prefix+e: current window, prefix+E: all windows)
+set -g @plugin 'hiroppy/tmux-agent-sidebar'
+
+# TPM (managed declaratively via nix in modules/tmux.nix)
+run '~/.config/tmux/plugins/tpm/tpm'
 
 # show pane synchronization status in status bar (center)
 set -g status 2

--- a/modules/ai-agent.nix
+++ b/modules/ai-agent.nix
@@ -709,16 +709,6 @@ in
             ];
           }
         ];
-        UserPromptSubmit = [
-          {
-            hooks = [
-              {
-                type = "command";
-                command = "workmux set-window-status working";
-              }
-            ];
-          }
-        ];
         PostToolUse = [
           {
             matcher = "Write|Edit";
@@ -727,15 +717,15 @@ in
                 type = "command";
                 command = "${promptEditHook}";
               }
-            ];
-          }
-          {
+              {
             hooks = [
               {
                 type = "command";
-                command = "workmux set-window-status working";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude activity-log";
               }
             ];
+          }
+        ];
           }
         ];
         TeammateIdle = [
@@ -745,7 +735,15 @@ in
                 type = "command";
                 command = "~/.claude/hooks/teammate-idle-gate.sh";
               }
+              {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude teammate-idle";
+              }
             ];
+          }
+        ];
           }
         ];
         TaskCompleted = [
@@ -755,7 +753,15 @@ in
                 type = "command";
                 command = "~/.claude/hooks/task-completed-gate.sh";
               }
+              {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude task-completed";
+              }
             ];
+          }
+        ];
           }
         ];
         Notification = [
@@ -765,16 +771,15 @@ in
                 type = "command";
                 command = "~/.claude/hooks/notify-send.sh";
               }
-            ];
-          }
-          {
-            matcher = "permission_prompt|elicitation_dialog";
+              {
             hooks = [
               {
                 type = "command";
-                command = "workmux set-window-status waiting";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude notification";
               }
             ];
+          }
+        ];
           }
         ];
         Stop = [
@@ -784,13 +789,93 @@ in
                 type = "command";
                 command = "~/.claude/hooks/notify-send.sh";
               }
+              {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude stop";
+              }
             ];
           }
+        ];
+          }
+        ];
+        SessionStart = [
           {
             hooks = [
               {
                 type = "command";
-                command = "workmux set-window-status done";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude session-start";
+              }
+            ];
+          }
+        ];
+        SessionEnd = [
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude session-end";
+              }
+            ];
+          }
+        ];
+        StopFailure = [
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude stop-failure";
+              }
+            ];
+          }
+        ];
+        PermissionDenied = [
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude permission-denied";
+              }
+            ];
+          }
+        ];
+        CwdChanged = [
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude cwd-changed";
+              }
+            ];
+          }
+        ];
+        SubagentStart = [
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude subagent-start";
+              }
+            ];
+          }
+        ];
+        SubagentStop = [
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude subagent-stop";
+              }
+            ];
+          }
+        ];
+        TaskCreated = [
+          {
+            hooks = [
+              {
+                type = "command";
+                command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude task-created";
               }
             ];
           }
@@ -878,9 +963,9 @@ in
           hooks = [
             {
               type = "command";
-              command = "workmux set-window-status working";
+              command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude user-prompt-submit";
               timeout = 5;
-              statusMessage = "Setting workmux status";
+              statusMessage = "tmux-agent-sidebar hook";
             }
             {
               type = "command";
@@ -909,9 +994,9 @@ in
           hooks = [
             {
               type = "command";
-              command = "workmux set-window-status done";
+              command = "bash ~/.tmux/plugins/tmux-agent-sidebar/hook.sh claude stop";
               timeout = 5;
-              statusMessage = "Setting workmux status";
+              statusMessage = "tmux-agent-sidebar hook";
             }
             {
               type = "command";

--- a/modules/tmux.nix
+++ b/modules/tmux.nix
@@ -1,6 +1,53 @@
-
 { config, pkgs, ... }:
 
+let
+  tmux-agent-sidebar-version = "0.10.1";
+
+  tmux-agent-sidebar-src = pkgs.fetchFromGitHub {
+    owner = "hiroppy";
+    repo = "tmux-agent-sidebar";
+    rev = "v${tmux-agent-sidebar-version}";
+    sha256 = "1bkhnxb9sw9r1vmby2dxf3hrzpsy3a90jmcxykf709rdzjh9wm1q";
+  };
+
+  tmux-agent-sidebar-bin = pkgs.fetchurl {
+    url =
+      let
+        asset =
+          if pkgs.stdenv.isDarwin then
+            (if pkgs.stdenv.isAarch64 then "tmux-agent-sidebar-darwin-aarch64" else "tmux-agent-sidebar-darwin-x86_64")
+          else
+            (if pkgs.stdenv.isAarch64 then "tmux-agent-sidebar-linux-aarch64" else "tmux-agent-sidebar-linux-x86_64");
+      in
+      "https://github.com/hiroppy/tmux-agent-sidebar/releases/download/v${tmux-agent-sidebar-version}/${asset}";
+    sha256 =
+      if pkgs.stdenv.isDarwin then
+        (if pkgs.stdenv.isAarch64 then
+          "0d41jy6m74xjzfjp5q4ar3z1798v93rygcxc0ks3xqwwx3g4066b"
+        else
+          "1xjyl8fpyv5xlv9rjkvh3g7v5hdh4a3nhc1wcd8kld1bjsf7lc97")
+      else
+        (if pkgs.stdenv.isAarch64 then
+          "177ykxh3ic9088kjsfwnd2h4gma1lsgbwzx9yj68hbgl01l8qbh8"
+        else
+          "1my9czk10irsc1vbdrlqh4j50b1yjl743s73inp73v37jzjjwm48");
+  };
+
+  tmux-agent-sidebar-plugin = pkgs.runCommand "tmux-agent-sidebar-${tmux-agent-sidebar-version}" { } ''
+    cp -r ${tmux-agent-sidebar-src} $out
+    chmod -R +w $out
+    mkdir -p $out/bin
+    cp ${tmux-agent-sidebar-bin} $out/bin/tmux-agent-sidebar
+    chmod +x $out/bin/tmux-agent-sidebar
+  '';
+
+  tpm-src = pkgs.fetchFromGitHub {
+    owner = "tmux-plugins";
+    repo = "tpm";
+    rev = "v3.1.0";
+    sha256 = "18i499hhxly1r2bnqp9wssh0p1v391cxf10aydxaa7mdmrd3vqh9";
+  };
+in
 {
   programs.tmux = {
     enable = true;
@@ -32,4 +79,10 @@ set -g @tokyo-night-tmux_show_wbg 0
     ];
   };
 
+  # TPM (tmux plugin manager) - declarative install
+  # home-manager's programs.tmux uses XDG path: ~/.config/tmux/plugins/
+  xdg.configFile."tmux/plugins/tpm".source = tpm-src;
+
+  # tmux-agent-sidebar plugin (source + pre-built binary)
+  xdg.configFile."tmux/plugins/tmux-agent-sidebar".source = tmux-agent-sidebar-plugin;
 }


### PR DESCRIPTION
workmuxサイドバーが重い問題への対処。ポーリング方式（workmux 2秒間隔のdaemon）からイベント駆動（tmux-agent-sidebar、Claude Code/Codex hookで状態push）に移行。

TPMとtmux-agent-sidebarバイナリは **完全に宣言的にnix管理**（手動セットアップ不要）。

## 削除

- `workmux set-window-status` hooks（Claude Code 4箇所 + Codex 2箇所）
- workmuxサイドバー関連キーバインド（`bind t/J/K`）

## 追加

### Claude Code / Codex hooks

- **tmux-agent-sidebar hook を14個登録**（Claude Code）
  - SessionStart, SessionEnd, UserPromptSubmit, PostToolUse, Notification, Stop, StopFailure, PermissionDenied, CwdChanged, SubagentStart, SubagentStop, TaskCreated, TaskCompleted, TeammateIdle
- **Codex hooksにも追加**（UserPromptSubmit, Stop）

### tmux plugins（modules/tmux.nix で宣言的管理）

- **TPM** v3.1.0 を `fetchFromGitHub` で取得、`xdg.configFile."tmux/plugins/tpm"` にsymlink
- **tmux-agent-sidebar** v0.10.1（source + pre-built binary）
  - source: `fetchFromGitHub`
  - binary: `fetchurl` でプラットフォーム別に取得（linux-x86_64 / linux-aarch64 / darwin-aarch64 / darwin-x86_64）
  - `runCommand` でsource + bin を統合して `xdg.configFile."tmux/plugins/tmux-agent-sidebar"` にsymlink
- tmux.conf: `run '~/.config/tmux/plugins/tpm/tpm'` でTPM起動

## 維持

- workmux dashboard（`prefix+w`）
- workmux last-done（`prefix+Tab`）
- workmux last-agent（`prefix+o`）
- workmux add/merge/remove等のworktree管理

## 適用後の手順

```bash
home-manager switch --flake . --impure
tmux kill-server  # 既存tmuxサーバーがある場合
tmux              # 起動 → 自動的にTPMがpluginをロード
# prefix + e でsidebar起動、prefix + E で全window
```

## ローカル動作確認（ai-tools, WSL/Linux）

- ✅ `home-manager switch` 成功
- ✅ `~/.config/tmux/plugins/{tpm,tmux-agent-sidebar}` がnix store のsymlink
- ✅ `~/.config/tmux/plugins/tmux-agent-sidebar/bin/tmux-agent-sidebar --version` → `0.10.1`
- ✅ Claude `~/.claude/settings.json` に 14イベントhook登録
- ✅ Codex `~/.codex/hooks.json` に hook登録
- ✅ `bind-key -T prefix e` が `tmux-agent-sidebar toggle` にマップされて自動的に有効化
- ✅ `@sidebar_key e` / `@sidebar_key_all E` オプション設定済み

## 既知の警告（既存問題・本PRと無関係）

- tmux.conf 125-127行の `set -uw` で起動時 'no current window' warning
