### PR TITLE
feat: claude-desktop (Linux 非公式ビルド) を導入

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,6 +116,27 @@
         "type": "github"
       }
     },
+    "claude-desktop": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780710221,
+        "narHash": "sha256-UWuDKE1O1PeKnlNzAGmRREwOOZR6F+cOYOiFT7o2KoM=",
+        "owner": "aaddrick",
+        "repo": "claude-desktop-debian",
+        "rev": "d99cdbd0e054fc04eb2ccfaf31777f11e89416c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aaddrick",
+        "repo": "claude-desktop-debian",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1766774972,
@@ -148,6 +169,24 @@
     },
     "flake-parts": {
       "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
         "nixpkgs-lib": [
           "llm-agents-nix",
           "nixpkgs"
@@ -167,9 +206,9 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1754487366,
@@ -185,9 +224,9 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1765835352,
@@ -308,7 +347,7 @@
       "inputs": {
         "blueprint": "blueprint",
         "bun2nix": "bun2nix",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs",
         "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
@@ -387,6 +426,21 @@
     },
     "nixpkgs-lib": {
       "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
         "lastModified": 1753579242,
         "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
@@ -400,7 +454,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_2": {
+    "nixpkgs-lib_3": {
       "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
@@ -468,6 +522,7 @@
         "agent-browser": "agent-browser",
         "agent-skills-nix": "agent-skills-nix",
         "apple-silicon": "apple-silicon",
+        "claude-desktop": "claude-desktop",
         "flake-utils": "flake-utils",
         "home-manager": "home-manager_2",
         "llm-agents-nix": "llm-agents-nix",
@@ -547,7 +602,7 @@
     },
     "try": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
@@ -567,7 +622,7 @@
     "xremap": {
       "inputs": {
         "crane": "crane",
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "nixpkgs": "nixpkgs_4",
         "xremap": "xremap_2"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,10 @@
       url = "github:0xc000022070/zen-browser-flake";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    claude-desktop = {
+      url = "github:aaddrick/claude-desktop-debian";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     apple-silicon = {
       url = "github:nix-community/nixos-apple-silicon";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/nixos/claude-desktop.nix
+++ b/modules/nixos/claude-desktop.nix
@@ -1,0 +1,14 @@
+{
+  pkgs,
+  inputs,
+  ...
+}:
+
+{
+  # Claude Desktop (非公式 Linux ビルド: aaddrick/claude-desktop-debian)
+  # 公式は macOS/Windows のみ。Linux は CLI が公式パスだが、GUI も使いたいので導入。
+  # MCP サーバーを使うため FHS 環境版 (claude-desktop-fhs) を選択。
+  home.packages = [
+    inputs.claude-desktop.packages.${pkgs.stdenv.hostPlatform.system}.claude-desktop-fhs
+  ];
+}


### PR DESCRIPTION
## 概要

Claude Desktop を Linux (NixOS) で使えるよう導入する。公式は macOS/Windows のみで Linux 版が存在しないため、公式 Windows 版を Linux 向けに再梱包する非公式ビルド [`aaddrick/claude-desktop-debian`](https://github.com/aaddrick/claude-desktop-debian) を flake input として採用した。

## 変更内容

- **flake.nix** — `claude-desktop` input を追加（`nixpkgs` を follows）
- **flake.lock** — input をロック（rev `d99cdbd`）
- **modules/nixos/claude-desktop.nix**（新規） — MCP 対応の FHS 版 `claude-desktop-fhs` を `home.packages` に追加。`modules/nixos/` 配下なので **NixOS 環境でのみ自動インポート**される

## 動作確認 (air / aarch64-linux)

- `nix build` で `claude-desktop-fhs` のビルド成功（Electron 41.7.1 同梱）
- Wayland 上で起動しクラッシュしないことを確認
- `sudo nixos-rebuild switch --flake .#air --impure` で反映、`/etc/profiles/per-user/ymat19/bin/claude-desktop` と `claude-desktop.desktop` の配置を確認
- rofi(drun) に `Name=Claude` として表示される

## 備考

- 本体は Electron 製。公式 Windows バイナリの `app.asar` を流用し、Electron ランタイムと一部ネイティブモジュールのみ Linux 用に差し替えた再梱包であり、Anthropic 公式サポート対象外。
- ビルドスクリプトは MIT/Apache-2.0、アプリ本体は Anthropic Consumer Terms に従う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)