### PR TITLE
fix: ターミナルのフォントをシステム標準(FiraCode)に揃える

### DIFF
--- a/configs/alacritty.toml
+++ b/configs/alacritty.toml
@@ -5,11 +5,9 @@
 opacity = 0.8
 decorations = "None"
 
+# family は指定せずシステムの monospace（FiraCode Nerd Font）にフォールバックさせる
 [font]
 size = 14
-normal = { family = "JetBrainsMono Nerd Font", style = "Regular" }
-bold = { family = "JetBrainsMono Nerd Font", style = "Bold" }
-italic = { family = "JetBrainsMono Nerd Font", style = "Italic" }
 
 [cursor]
 style = { shape = "Beam", blinking = "Off" }

--- a/modules/nixos/alacritty.nix
+++ b/modules/nixos/alacritty.nix
@@ -5,6 +5,4 @@
     enable = true;
     settings = builtins.fromTOML (builtins.readFile ../../configs/alacritty.toml);
   };
-
-  home.packages = [ pkgs.nerd-fonts.jetbrains-mono ];
 }


### PR DESCRIPTION
## 概要

alacritty でフォントが当たっていなかった問題を修正する。

## 原因

- alacritty は `JetBrainsMono Nerd Font` を明示指定していた（`configs/alacritty.toml`）。
- JetBrainsMono は `modules/nixos/alacritty.nix` の `home.packages` で導入していたが、本リポジトリは home-manager を NixOS モジュール（`useUserPackages = true`）として動かしているため、`home.packages` のフォントはシステムの fontconfig にスキャンされない。
- 結果、alacritty は JetBrainsMono を見つけられずデフォルトフォントにフォールバックしていた（`fc-list` にも JetBrains は存在しなかった）。

## 変更

- `configs/alacritty.toml`: `font.family` の固定指定を削除し、システムの monospace（`FiraCode Nerd Font`）にフォールバックさせる。
- `modules/nixos/alacritty.nix`: 効いていなかった `home.packages` のフォント行を削除。

システムフォントは `nixos-configurations/baremetal.nix` の `fonts.packages` / `fontconfig.defaultFonts.monospace` で `FiraCode Nerd Font` が登録済みのため、フォント管理がシステム側に一元化される。

## 確認

- `fc-match monospace` → `FiraCode Nerd Font` を確認。
- `nix flake check --no-build` 通過。
- `air` ホストで `nixos-rebuild switch` 済み。新規ウィンドウでフォント適用を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)