### PR TITLE
mosh: WSL用 mosh-server-wrap を dotfiles 管理化

### DIFF
--- a/modules/mosh.nix
+++ b/modules/mosh.nix
@@ -2,9 +2,16 @@
   config,
   pkgs,
   lib,
+  onWSL ? false,
   ...
 }:
 
+let
+  # WSL 向け mosh-server ラッパー（詳細は scripts/mosh-server-wrap.sh 参照）。
+  mosh-server-wrap = pkgs.writeShellScriptBin "mosh-server-wrap" (
+    builtins.readFile ../scripts/mosh-server-wrap.sh
+  );
+in
 {
   # mosh は client (mosh / mosh-client) と server (mosh-server) の両方を含む。
   # 全ホストにクライアントとして入れておく。
@@ -16,4 +23,10 @@
       mosh
     ]
   );
+
+  # WSL では mirrored networking のため mosh-server をそのまま使えない。
+  # ラッパーを ~/bin に置き、mosh client 側から --server で指定して使う。
+  home.file = lib.mkIf onWSL {
+    "bin/mosh-server-wrap".source = "${mosh-server-wrap}/bin/mosh-server-wrap";
+  };
 }

--- a/scripts/mosh-server-wrap.sh
+++ b/scripts/mosh-server-wrap.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# WSL 向け mosh-server ラッパー。
+# WSL の mirrored networking 環境では LAN から WSL への直接 UDP が通らないため、
+# 実体の mosh-server を 127.0.0.1 の 60001-60010 に bind させ、announce される
+# "MOSH CONNECT <port>" を <port>+OFFSET に書き換える。これにより mosh client は
+# ホスト側の UDP フォワーダポート (61001-61010) を狙い、そこから 127.0.0.1:<port>
+# へ中継される。
+OFFSET=1000
+
+REAL=""
+for c in "$HOME/.nix-profile/bin/mosh-server" "$(command -v mosh-server 2>/dev/null)" /usr/bin/mosh-server /usr/local/bin/mosh-server "$HOME/.local/bin/mosh-server"; do
+  if [ -n "$c" ] && [ -x "$c" ]; then REAL="$c"; break; fi
+done
+if [ -z "$REAL" ]; then echo "mosh-server not found in this distro" >&2; exit 127; fi
+
+args=()
+ins=0
+for a in "$@"; do
+  if [ "$a" = "--" ] && [ "$ins" = "0" ]; then
+    args+=( -p 60001:60010 -- )
+    ins=1
+  else
+    args+=( "$a" )
+  fi
+done
+[ "$ins" = "0" ] && args+=( -p 60001:60010 )
+
+out="$("$REAL" "${args[@]}" 2>&1)"
+printf '%s\n' "$out" | awk -v off="$OFFSET" \
+  '/^MOSH CONNECT/{printf "MOSH CONNECT %d %s\n", $3+off, $4; next} {print}'


### PR DESCRIPTION
## 概要

`~/bin/mosh-server-wrap` を手動配置から dotfiles 管理へ移管する。

WSL の mirrored networking 環境では LAN→WSL の直接 UDP が通らないため、実体の `mosh-server` を `127.0.0.1:60001-60010` に bind させ、announce される `MOSH CONNECT <port>` を `<port>+1000` に書き換えて host 側 UDP フォワーダ (61001-61010) 経由で中継する、というラッパー。

## 変更点

- `scripts/mosh-server-wrap.sh` — ラッパー本体（業務端末特有の情報は含めず、ポート番号とロジックのみ。コメントを home-manager 管理の実態に合わせて更新）。
- `modules/mosh.nix` — `writeShellScriptBin` で生成し、**`onWSL` 時のみ** `~/bin/mosh-server-wrap` へ配置（`lib.mkIf onWSL`）。呼び出し元が絶対パス参照のため設置パスは従来どおり維持。

## 検証

- `nixfmt` 整形済み（差分なし）、`nix flake check --no-build` 通過。
- 判定が NixOS 非依存であることを確認（`/etc/nixos` 無→standalone、`/mnt/c/Windows` 有→onWSL）。Ubuntu WSL でも分岐に入る。
- 実機で `home-manager switch --flake . --impure` 成功 → `~/bin/mosh-server-wrap` が nix store 管理の symlink として配置され、実体 mosh-server への委譲・OFFSET/ポート書き換えロジックの動作を確認。

## 適用メモ

初回 switch 前に既存の実ファイル `~/bin/mosh-server-wrap` を削除する必要あり（スタンドアロン構成は `backupFileExtension` 未設定のため）。本 PR の検証時に対応済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)