### PR TITLE
mosh越しでtmuxコピーモードのクリップボードを反映 (#91の正しい修正)

### DIFF
--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -33,13 +33,6 @@ if-shell -b '[ "$(uname)" = "Darwin" ]' {
 # copy-pipe と競合する場合があるので無効化
 set -s set-clipboard on
 
-# mosh 越しでもクリップボードへ反映させる
-# tmux は set-clipboard on のとき OSC 52 を `ESC]52;;<base64>` (種別が空) で送る。
-# SSH は透過するのでローカル端末がコピーするが、mosh 1.4.0 は `c;` (clipboard 指定)
-# 付きの OSC 52 しか受理せず空指定を無視するため反映されない。
-# tmux が OSC 52 送出に使う Ms capability を上書きして `c;` を強制する。
-set -ag terminal-overrides ",*:Ms=\\E]52;c;%p2%s\\7"
-
 # コピーモード中に Vim 風に v で選択範囲を定める
 bind -Tcopy-mode-vi v send -X begin-selection
 

--- a/modules/mosh.nix
+++ b/modules/mosh.nix
@@ -7,7 +7,20 @@
 }:
 
 let
+  # mosh 1.4.0 はクリップボード(OSC 52)を `52;c;` 形式しか受理せず、
+  # tmux のコピーモードが送出する種別フィールド空の `52;;` を破棄する。
+  # このため mosh 越しだと tmux でコピーしてもローカルのクリップボードへ
+  # 反映されない (SSH は透過なので Windows Terminal 等が直接受理でき動く)。
+  # mosh-server 側のパーサを `52;<sel>;` (sel は空でも可) を受理するよう
+  # パッチして根本解決する。mosh-client は元々 `52;c;` を端末へ再送出するので
+  # ローカル端末側は無改造で動作する。
+  moshClipboard = pkgs.mosh.overrideAttrs (old: {
+    patches = (old.patches or [ ]) ++ [ ../patches/mosh-osc52-accept-empty-selection.patch ];
+  });
+
   # WSL 向け mosh-server ラッパー（詳細は scripts/mosh-server-wrap.sh 参照）。
+  # ラッパーは実体の mosh-server を $HOME/.nix-profile/bin/mosh-server から探すため、
+  # home.packages の moshClipboard により自動的にパッチ版 mosh-server が使われる。
   mosh-server-wrap = pkgs.writeShellScriptBin "mosh-server-wrap" (
     builtins.readFile ../scripts/mosh-server-wrap.sh
   );
@@ -20,7 +33,7 @@ in
   home.packages = lib.mkAfter (
     with pkgs;
     [
-      mosh
+      moshClipboard
     ]
   );
 

--- a/patches/mosh-osc52-accept-empty-selection.patch
+++ b/patches/mosh-osc52-accept-empty-selection.patch
@@ -1,0 +1,29 @@
+--- a/src/terminal/terminalfunctions.cc
++++ b/src/terminal/terminalfunctions.cc
+@@ -591,13 +591,19 @@
+ /* xterm uses an Operating System Command to set the window title */
+ void Dispatcher::OSC_dispatch( const Parser::OSC_End *act __attribute((unused)), Framebuffer *fb )
+ {
+-  /* handle osc copy clipboard sequence 52;c; */
+-  if ( OSC_string.size() >= 5 && OSC_string[ 0 ] == L'5' &&
+-       OSC_string[ 1 ] == L'2' && OSC_string[ 2 ] == L';' &&
+-       OSC_string[ 3 ] == L'c' && OSC_string[ 4 ] == L';') {
+-      Terminal::Framebuffer::title_type clipboard(
+-              OSC_string.begin() + 5, OSC_string.end() );
+-      fb->set_clipboard( clipboard );
++  /* handle osc copy clipboard sequence 52;<sel>;
++     The selection field may be empty: tmux (>=3.x) emits "52;;<base64>",
++     while xterm emits "52;c;<base64>". Accept any selection field so that
++     copy-mode over tmux works (otherwise mosh silently drops the clipboard). */
++  if ( OSC_string.size() >= 3 && OSC_string[ 0 ] == L'5' &&
++       OSC_string[ 1 ] == L'2' && OSC_string[ 2 ] == L';' ) {
++      size_t sep = 3;
++      while ( sep < OSC_string.size() && OSC_string[ sep ] != L';' ) { sep++; }
++      if ( sep < OSC_string.size() ) {
++          Terminal::Framebuffer::title_type clipboard(
++                  OSC_string.begin() + sep + 1, OSC_string.end() );
++          fb->set_clipboard( clipboard );
++      }
+   /* handle osc terminal title sequence */
+   } else if ( OSC_string.size() >= 1 ) {
+     long cmd_num = -1;


### PR DESCRIPTION
## 概要
mosh 越しの tmux でコピーモードでコピーしてもローカルのクリップボードへ反映されない問題を、**mosh 側のパッチ**で根本修正する。あわせて #91 で入れた効果のない tmux 設定を撤去する。本ブランチは #92（WSL 用 mosh-server-wrap）の上に rebase 済み。

## #91 が誤りだった点
#91 は「tmux の `Ms` capability を上書きして OSC 52 を `52;c;` 形式に強制」する内容だったが、**実機検証の結果これは無効（no-op）**だった。tmux 3.6a はコピー/バッファ経路で `Ms` の terminal-override を参照しておらず、上書きしても出力は種別フィールド空の `52;;` のままだった。

## 実証した根本原因
pty 上で tmux と mosh の生バイトを捕捉して確認した:

| 経路 | tmux の送出 | 種別 |
|---|---|---|
| アプリの OSC52 (passthrough) | `ESC]52;c;…` | `c` |
| **コピーモード / set-buffer -w** | `ESC]52;;…` | **空** |

- tmux 3.6a は**コピー時に種別フィールドが空の `52;;` を送出する**。
- mosh 1.4.0 の OSC パーサ (`terminalfunctions.cc`) は `52;c;` のみ受理し `52;;` を破棄する。
- SSH はバイト透過なので Windows Terminal が `52;;` を直接受理して動く → 「SSH は反映 / mosh は非反映」。

## 修正
mosh-server のパーサを `52;<sel>;`（`sel` は空でも可）を受理するようパッチする（`patches/mosh-osc52-accept-empty-selection.patch`、`modules/mosh.nix` で `overrideAttrs`）。mosh-client は元々 `52;c;` を端末へ再送出するため、ローカル端末側は無改造で動作する。

WSL 用 `mosh-server-wrap`（#92）は実体の mosh-server を `$HOME/.nix-profile/bin/mosh-server` から探すため、`home.packages` の patched mosh により**ラッパー経由でも自動的にパッチ版 server が使われる**（ラッパー改造不要）。

## 検証（パッチ版 mosh を実ビルドし mosh-server↔client を直結）
| ペインが出す形式 | mosh-server | mosh-client の再送出 | 結果 |
|---|---|---|---|
| `52;c;`（対照） | 未パッチ | `ESC]52;c;…`（復号 `CLIPDATA`） | 反映（健全性確認） |
| `52;;`（tmux形式） | 未パッチ | なし | 非反映＝**バグ再現** |
| `52;;` | パッチ版 | `ESC]52;c;…`（復号 `CLIPDATA`） | **反映＝修正成功** |

- パッチは pinned nixpkgs の mosh 1.4.0 にクリーン適用、ビルド通過。
- `nix flake check --no-build` 通過（rebase 後・onWSL 経路含む）。

## 適用手順
このパッチは **mosh-server 側（= tmux を動かすホスト）** で効く。
1. サーバ側ホスト（例: 192.168.0.22）を home-manager で `onWSL=true` 含め rebuild
   → `~/bin/mosh-server-wrap` 生成 ＋ `~/.nix-profile/bin/mosh-server` がパッチ版に
2. `mosh --ssh="ssh -p 9922" --server=/home/ymat19/bin/mosh-server-wrap ymat19@192.168.0.22` で接続
   → ラッパーがパッチ版 server を起動し、tmux コピーがクリップボードへ反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)