### PR TITLE
tmux: lazygit popup を worktree 対応に

### DIFF
--- a/modules/tui-tools.nix
+++ b/modules/tui-tools.nix
@@ -58,11 +58,27 @@
         command lazydocker "$@"
       fi
     }
+
+    # tmux popup 用: cwd が git リポジトリ内ならそれを即開く（最優先）。
+    # リポジトリ外のときだけ、並列実行中の agent の worktree を fzf で選んで開く。
+    function lazygit-here {
+      if git rev-parse --is-inside-work-tree > /dev/null 2>&1
+      then
+        lazygit
+        return
+      fi
+      local sel dir
+      sel=$(claude agents --json 2>/dev/null \
+        | jq -r '.[] | select(.cwd | test("/.claude/worktrees/")) | "\(.name // .sessionId)\t\(.cwd)"' \
+        | fzf --delimiter='\t' --with-nth=1 --prompt='worktree > ') || return
+      dir=$(printf '%s' "$sel" | cut -f2)
+      [ -n "$dir" ] && cd "$dir" && lazygit
+    }
   '';
 
   programs.tmux.extraConfig = lib.mkAfter ''
     # https://www.m3tech.blog/entry/dotfiles-bonsai#Tmux%E7%B7%A8
-    bind g popup -d '#{pane_current_path}' -w90% -h90% -E zsh -c "source ~/.zshrc && lazygit"
+    bind g popup -d '#{pane_current_path}' -w90% -h90% -E zsh -c "source ~/.zshrc && lazygit-here"
     bind q popup -d '#{pane_current_path}' -w90% -h90% -E zsh -c "source ~/.zshrc && lazydocker"
   '';
 }


### PR DESCRIPTION
## 背景

agent view から dispatch した background agent は git worktree (`.claude/worktrees/*`) で作業する。しかし tmux の `prefix+g` で開く lazygit は `#{pane_current_path}`（= agent view を集約している元 pane の cwd）で開くため、目的の worktree にならず不便だった。

調査の結果、「今フォーカスしている agent」はディスクに一切記録されない（`claude agents --json` にも `~/.claude/sessions/*.json` にも focus/attach 系フィールドが無い）ことを確認。フォーカスの自動特定は不可能なため、cwd 判定 + fzf 選択で対応する。

## 変更

`modules/tui-tools.nix` に `lazygit-here` を追加し、`bind g` を付け替え:

- **cwd が git リポジトリ内 → 問答無用で即 `lazygit`**（最優先・worktree の個数は見ない）
- **cwd がリポジトリ外 → 必ず fzf で worktree 選択**（`claude agents --json` から `.claude/worktrees/` 配下の agent cwd を `名前` で一覧）→ `cd` して `lazygit`

- WSL の `lazygit.exe` ラッパも従来通り経由
- LLM を呼ばないため**追加トークン消費ゼロ**（`claude agents --json` はローカルプロセス問い合わせ）

## テスト

- `jq` / `fzf` / `claude` / `lazygit` の存在確認 ✅
- fzf 候補生成ロジックを実動テスト（並列中の3 worktree が正しく列挙）✅
- `nix flake check --no-build` 通過 ✅
- tmux popup 内の最終統合動作は `home-manager switch` 後の実機で要確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)