### PR TITLE
herdr: ghq リポジトリから worktree+ワークスペースを作る keybind を追加

### DIFF
--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -17,6 +17,12 @@ type = "pane"
 command = "zsh -c 'source ~/.zshrc && lazydocker'"
 description = "lazydocker"
 
+[[keys.command]]
+key = "prefix+shift+c"
+type = "pane"
+command = "zsh -c 'source ~/.zshrc && hwt'"
+description = "ghq repo を fzf 選択して worktree+ワークスペース作成"
+
 [theme]
 name = "tokyo-night"
 

--- a/configs/zshrc
+++ b/configs/zshrc
@@ -15,3 +15,22 @@ zle -N edit-command-line
 bindkey '^g' edit-command-line
 bindkey -s '^y' 'try\n'
 
+# herdr: ghq リポジトリを fzf で選び、その repo に worktree+ワークスペースを作成
+# herdr の [[keys.command]] (type=pane) から呼ぶ想定。fzf/read は実ペインの TTY で動く
+# base はリモート既定ブランチ(origin/HEAD)を自動判定して fetch 後に採用（master/main 混在に対応）
+# origin が無い/取得失敗時はローカル HEAD から切る
+hwt() {
+  local repo branch remote_head
+  repo=$(ghq list -p | fzf --prompt 'repo> ') || return
+  [ -n "$repo" ] || return
+  read "branch?branch> " || return
+  [ -n "$branch" ] || return
+  remote_head=$(git -C "$repo" ls-remote --symref origin HEAD 2>/dev/null \
+    | awk '/^ref:/ {sub("refs/heads/", "", $2); print $2; exit}')
+  if [ -n "$remote_head" ] && git -C "$repo" fetch origin "$remote_head" --quiet 2>/dev/null; then
+    herdr worktree create --cwd "$repo" --branch "$branch" --base "origin/$remote_head" --label "$branch"
+  else
+    herdr worktree create --cwd "$repo" --branch "$branch" --label "$branch"
+  fi
+}
+


### PR DESCRIPTION
## 概要

`prefix+shift+c` で ghq リポジトリを fzf 選択し、そのリポジトリの worktree を切って herdr ワークスペースを一発で作れる keybind (`hwt` 関数) を追加。`~/repos` 起点でも cd や専用シェルなしに、任意リポジトリの並行作業を開始できる。

## 変更内容

- **`configs/zshrc`**: `hwt` 関数を追加
  - `ghq list -p | fzf` でリポジトリ選択 → ブランチ名入力
  - `git ls-remote --symref origin HEAD` でリモート既定ブランチを自動判定（master/main 混在に対応）
  - fetch 後 `--base origin/<既定>` で worktree 作成。origin 無し/取得失敗時はローカル HEAD にフォールバック
- **`configs/herdr/config.toml`**: `prefix+shift+c` に上記 `hwt` を割り当てる `[[keys.command]]`（`type = "pane"` で TTY 確保、fzf/read が動作）

## 検証

- `herdr worktree create --cwd/--branch/--base/--label` のフラグ実在を確認
- worktree+ワークスペースの生成→完全削除（checkout・ブランチ）を実機で確認
- リモート既定ブランチ検出が dotfiles で `main` を返すことを確認
- `zsh -n` 構文チェック OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)