### PR TITLE
feat(shell): abbr で cc→claude -c 等のショートカットを追加

### DIFF
--- a/configs/zshrc
+++ b/configs/zshrc
@@ -9,8 +9,9 @@ export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
 # abbr (zsh-abbr): コマンド入力時にスペース/Enter で展開される略語。
 # セッションスコープ (-S) で宣言し、ユーザーファイルには永続化しない（宣言的に管理するため）。
 if (( $+functions[abbr] )); then
-  abbr -S -q cc='claude -c' 2>/dev/null    # 直前のセッションを継続
-  abbr -S -q ccr='claude -r' 2>/dev/null   # セッションを選んで再開
+  abbr -S -q cc='claude -c' 2>/dev/null        # 直前のセッションを継続
+  abbr -S -q cr='claude -r' 2>/dev/null        # セッションを選んで再開
+  abbr -S -q ca='claude agents' 2>/dev/null    # agent view
 fi
 
 bindkey -v

--- a/configs/zshrc
+++ b/configs/zshrc
@@ -5,6 +5,14 @@ if command -v herdr >/dev/null; then
 fi
 
 export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+
+# abbr (zsh-abbr): コマンド入力時にスペース/Enter で展開される略語。
+# セッションスコープ (-S) で宣言し、ユーザーファイルには永続化しない（宣言的に管理するため）。
+if (( $+functions[abbr] )); then
+  abbr -S -q cc='claude -c' 2>/dev/null    # 直前のセッションを継続
+  abbr -S -q ccr='claude -r' 2>/dev/null   # セッションを選んで再開
+fi
+
 bindkey -v
 bindkey 'jj' vi-cmd-mode
 bindkey -M viins '^a' beginning-of-line

--- a/modules/shell.nix
+++ b/modules/shell.nix
@@ -31,6 +31,14 @@
         "aws"
       ];
     };
+    # fish 風の abbr（入力時に展開される略語）。展開の実体は configs/zshrc で定義する
+    plugins = [
+      {
+        name = "zsh-abbr";
+        src = pkgs.zsh-abbr;
+        file = "share/zsh/zsh-abbr/zsh-abbr.zsh";
+      }
+    ];
   };
 
   programs.bash = {


### PR DESCRIPTION
## 概要

fish 風の abbr（コマンド入力時に展開される略語）を zsh に導入し、`cc` → `claude -c` などのショートカットを追加する。

## 変更点

- `modules/shell.nix`: `zsh-abbr` プラグインを `programs.zsh.plugins` に追加
- `configs/zshrc`: セッションスコープ (`-S`) の略語を宣言的に定義（ユーザーファイルには永続化しない）

## 追加した略語

| 略語 | 展開先 | 用途 |
|------|--------|------|
| `cc`  | `claude -c` | 直前のセッションを継続 |
| `ccr` | `claude -r` | セッションを選んで再開 |

## 挙動

`cc` と入力してスペース/Enter を押すと `claude -c` に展開される。alias と違い、展開後のコマンドが履歴・入力行にそのまま残るため何が実行されるか可視化される。

## 動作確認

- [ ] `home-manager switch --flake . --impure`（または `nixos-rebuild switch`）後に新しい zsh で `cc<space>` が `claude -c` に展開されること

> nix コマンドが利用できない環境のため、ローカルでの `nix flake check` は未実施。レビュー環境での rebuild 確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbcWR47dvVyV2DCb4fVp4f)_