### PR TITLE
fix(niri): XWayland(xwayland-satellite)を導入し Steam 等 X11 アプリを起動可能に

### DIFF
--- a/configs/niri-base.kdl
+++ b/configs/niri-base.kdl
@@ -183,6 +183,13 @@ binds {
 
 spawn-at-startup "fcitx5"
 spawn-at-startup "alacritty" "--class" "alacritty-scratch"
+// XWayland を xwayland-satellite で提供（Steam 等の X11 アプリに必須）
+spawn-at-startup "xwayland-satellite" ":0"
+
+// X11 アプリが XWayland(:0) に接続できるよう DISPLAY を設定
+environment {
+    DISPLAY ":0"
+}
 
 // Monitor configuration
 output "DP-3" {

--- a/modules/nixos/niri.nix
+++ b/modules/nixos/niri.nix
@@ -7,8 +7,25 @@
   ...
 }:
 
+let
+  # xwayland-satellite 0.8.1 は出力(モニタ)が一時的に 0 個になると panic するバグがあり
+  # （画面ブランク/スリープで出力が一瞬消えた時など）、落ちると X(:0) ごと
+  # Steam 等の X11 アプリを巻き込んで落とす。nixpkgs は 0.8.1 が最新のため、
+  # 上流の修正コミット "avoid panic when no outputs are present" をパッチとして当てる。
+  # https://github.com/Supreeeme/xwayland-satellite/commit/10f985b8
+  xwayland-satellite-fixed = pkgs.xwayland-satellite.overrideAttrs (old: {
+    patches = (old.patches or [ ]) ++ [
+      (pkgs.fetchpatch {
+        name = "xwls-avoid-panic-no-outputs.patch";
+        url = "https://github.com/Supreeeme/xwayland-satellite/commit/10f985b84cdbcc3bbf35b3e7e43d1b2a84fa9ce2.patch";
+        hash = "sha256-caWdCnbD4Yf7U9mdeMwYP1/xDjGg1jNvL1y2pq/C2GM=";
+      })
+    ];
+  });
+in
 {
   home.packages = with pkgs; [
+    xwayland-satellite-fixed # niri 用 XWayland（0.8.1 の panic 修正パッチ適用）
     waypaper
     adwaita-qt
     adwaita-qt6


### PR DESCRIPTION
## 背景 / 症状
niri 上で **Steam が起動しない**（`Unable to open a connection to X` ダイアログが出る）。さらに、一時的に起動できても**画面ブランク/スリープで目を離すとクラッシュ**する状態だった。

## 根本原因
1. **niri は XWayland を内蔵しない**。X11 アプリである Steam は接続先の X が無く起動不能だった（`DISPLAY` 未設定・`/tmp/.X11-unix` 空・Xwayland プロセス無し）。
2. XWayland を提供する **`xwayland-satellite` 0.8.1 にパニックバグ**があり、出力(モニタ)が一時的に 0 個になると `src/server/mod.rs` の `outputs.next().unwrap()` で panic → X(:0) ごと落ち、接続中の Steam も巻き添えで落ちる。画面ブランク/スリープ時に出力が一瞬消えることが引き金。

## 対応
- `xwayland-satellite` パッケージを追加（niri がネイティブに spawn/管理し、クラッシュ時も自動再起動する）
- nixpkgs は 0.8.1 が最新のため、上流の修正コミット [`10f985b8` "avoid panic when no outputs are present"](https://github.com/Supreeeme/xwayland-satellite/commit/10f985b84cdbcc3bbf35b3e7e43d1b2a84fa9ce2)（`unwrap()` → `if let Some`）を **fetchpatch でパッチ適用**
- X11 アプリが XWayland(:0) に接続できるよう `environment { DISPLAY ":0" }` を niri 設定に追加

## 検証
- パッチ適用版のビルド・テスト通過を確認
- `nixos-rebuild switch --flake .#main` 成功
- 稼働中の satellite がパッチ版に切り替わったことを実測確認（旧版 kill → niri がパッチ版を自動再 spawn）、`xset -display :0 q` で X 疎通 OK、Steam のウィンドウ表示を確認

## 備考
`configs/niri-base.kdl` の `spawn-at-startup "xwayland-satellite"` は、niri がネイティブ管理するため実質冗長な安全網。

🤖 Generated with [Claude Code](https://claude.com/claude-code)